### PR TITLE
Moves hyphen as last arg.

### DIFF
--- a/module01/README.md
+++ b/module01/README.md
@@ -130,7 +130,7 @@ go test
 
 ```bash
 go_test() {
-  go test $* | sed ''/PASS/s//$(printf "\033[32mPASS\033[0m")/'' | sed ''/SKIP/s//$(printf "\033[34mSKIP\033[0m")/'' | sed ''/FAIL/s//$(printf "\033[31mFAIL\033[0m")/'' | sed ''/FAIL/s//$(printf "\033[31mFAIL\033[0m")/'' | GREP_COLOR="01;33" egrep --color=always '\s*[a-zA-Z0-9\-_.]+[:][0-9]+[:]|^'
+  go test $* | sed ''/PASS/s//$(printf "\033[32mPASS\033[0m")/'' | sed ''/SKIP/s//$(printf "\033[34mSKIP\033[0m")/'' | sed ''/FAIL/s//$(printf "\033[31mFAIL\033[0m")/'' | sed ''/FAIL/s//$(printf "\033[31mFAIL\033[0m")/'' | GREP_COLOR="01;33" egrep --color=always '\s*[a-zA-Z0-9_.-]+[:][0-9]+[:]|^'
 }
 ```
 


### PR DESCRIPTION
Hyphen in [...] returns an error : "grep: Invalid range end"
In my opinion in this case, hyphen needs to be last or first.